### PR TITLE
wandb call retry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ torch>=1.9,<1.13             # needed by: torch,pytorch_lightning,transformers,f
 numpy                        # needed by: torch,pytorch_lightning,transformers,fairscale
 datasets>=1.12,<3            # needed by: datasets,transformers
 wandb>=0.12,<0.14            # needed by: wandb
+retry                        # needed by: wandb
 pytorch-lightning>=1.6,<1.8  # needed by: pytorch_lightning
 transformers>=4.12.3         # needed by: transformers
 sentencepiece==0.1.97        # needed by: transformers

--- a/tango/integrations/wandb/step_cache.py
+++ b/tango/integrations/wandb/step_cache.py
@@ -61,9 +61,9 @@ class WandbStepCache(LocalStepCache):
         return f"{app_url}/{self.entity}/{self.project}"
 
     def _acquire_step_lock_file(self, step: Union[Step, StepInfo], read_only_ok: bool = False):
-        return FileLock(self.step_dir(step).with_suffix(".lock"), read_only_ok=read_only_ok).acquire_with_updates(
-            desc=f"acquiring step cache lock for '{step.unique_id}'"
-        )
+        return FileLock(
+            self.step_dir(step).with_suffix(".lock"), read_only_ok=read_only_ok
+        ).acquire_with_updates(desc=f"acquiring step cache lock for '{step.unique_id}'")
 
     def _step_artifact_name(self, step: Union[Step, StepInfo]) -> str:
         if isinstance(step, Step):
@@ -71,7 +71,9 @@ class WandbStepCache(LocalStepCache):
         else:
             return step.step_class_name
 
-    def get_step_result_artifact(self, step: Union[Step, StepInfo]) -> Optional[wandb.apis.public.Artifact]:
+    def get_step_result_artifact(
+        self, step: Union[Step, StepInfo]
+    ) -> Optional[wandb.apis.public.Artifact]:
         artifact_kind = (step.metadata or {}).get("artifact_kind", ArtifactKind.STEP_RESULT.value)
         try:
             return self.wandb_client.artifact(
@@ -84,7 +86,9 @@ class WandbStepCache(LocalStepCache):
             else:
                 raise
 
-    def create_step_result_artifact(self, step: Step, objects_dir: Optional[PathOrStr] = None) -> None:
+    def create_step_result_artifact(
+        self, step: Step, objects_dir: Optional[PathOrStr] = None
+    ) -> None:
         """
         Create an artifact for the result of a step.
         """
@@ -108,7 +112,8 @@ class WandbStepCache(LocalStepCache):
     def get_step_result_artifact_url(self, step: Union[Step, StepInfo]) -> str:
         artifact_kind = (step.metadata or {}).get("artifact_kind", ArtifactKind.STEP_RESULT.value)
         return (
-            f"{self.wandb_project_url}/artifacts/{artifact_kind}" f"/{self._step_artifact_name(step)}/{step.unique_id}"
+            f"{self.wandb_project_url}/artifacts/{artifact_kind}"
+            f"/{self._step_artifact_name(step)}/{step.unique_id}"
         )
 
     @retry(RuntimeError, delay=10, backoff=2, max_delay=120)
@@ -118,7 +123,9 @@ class WandbStepCache(LocalStepCache):
         """
         if wandb.run is None:
             raise RuntimeError("This can only be called from within a W&B run")
-        wandb.run.use_artifact(f"{self.entity}/{self.project}/{self._step_artifact_name(step)}:{step.unique_id}")
+        wandb.run.use_artifact(
+            f"{self.entity}/{self.project}/{self._step_artifact_name(step)}:{step.unique_id}"
+        )
 
     def __contains__(self, step: Any) -> bool:
         if isinstance(step, (Step, StepInfo)):

--- a/tango/integrations/wandb/step_cache.py
+++ b/tango/integrations/wandb/step_cache.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 from pathlib import Path
 from typing import Any, Optional, Union
+from retry import retry
 
 import wandb
 from wandb.errors import Error as WandbError
@@ -60,9 +61,9 @@ class WandbStepCache(LocalStepCache):
         return f"{app_url}/{self.entity}/{self.project}"
 
     def _acquire_step_lock_file(self, step: Union[Step, StepInfo], read_only_ok: bool = False):
-        return FileLock(
-            self.step_dir(step).with_suffix(".lock"), read_only_ok=read_only_ok
-        ).acquire_with_updates(desc=f"acquiring step cache lock for '{step.unique_id}'")
+        return FileLock(self.step_dir(step).with_suffix(".lock"), read_only_ok=read_only_ok).acquire_with_updates(
+            desc=f"acquiring step cache lock for '{step.unique_id}'"
+        )
 
     def _step_artifact_name(self, step: Union[Step, StepInfo]) -> str:
         if isinstance(step, Step):
@@ -70,9 +71,7 @@ class WandbStepCache(LocalStepCache):
         else:
             return step.step_class_name
 
-    def get_step_result_artifact(
-        self, step: Union[Step, StepInfo]
-    ) -> Optional[wandb.apis.public.Artifact]:
+    def get_step_result_artifact(self, step: Union[Step, StepInfo]) -> Optional[wandb.apis.public.Artifact]:
         artifact_kind = (step.metadata or {}).get("artifact_kind", ArtifactKind.STEP_RESULT.value)
         try:
             return self.wandb_client.artifact(
@@ -85,9 +84,7 @@ class WandbStepCache(LocalStepCache):
             else:
                 raise
 
-    def create_step_result_artifact(
-        self, step: Step, objects_dir: Optional[PathOrStr] = None
-    ) -> None:
+    def create_step_result_artifact(self, step: Step, objects_dir: Optional[PathOrStr] = None) -> None:
         """
         Create an artifact for the result of a step.
         """
@@ -111,19 +108,17 @@ class WandbStepCache(LocalStepCache):
     def get_step_result_artifact_url(self, step: Union[Step, StepInfo]) -> str:
         artifact_kind = (step.metadata or {}).get("artifact_kind", ArtifactKind.STEP_RESULT.value)
         return (
-            f"{self.wandb_project_url}/artifacts/{artifact_kind}"
-            f"/{self._step_artifact_name(step)}/{step.unique_id}"
+            f"{self.wandb_project_url}/artifacts/{artifact_kind}" f"/{self._step_artifact_name(step)}/{step.unique_id}"
         )
 
+    @retry(RuntimeError, delay=10, backoff=2, max_delay=120)
     def use_step_result_artifact(self, step: Union[Step, StepInfo]) -> None:
         """
         "Use" the artifact corresponding to the result of a step.
         """
         if wandb.run is None:
             raise RuntimeError("This can only be called from within a W&B run")
-        wandb.run.use_artifact(
-            f"{self.entity}/{self.project}/{self._step_artifact_name(step)}:{step.unique_id}"
-        )
+        wandb.run.use_artifact(f"{self.entity}/{self.project}/{self._step_artifact_name(step)}:{step.unique_id}")
 
     def __contains__(self, step: Any) -> bool:
         if isinstance(step, (Step, StepInfo)):


### PR DESCRIPTION

Adds a retry loop to wandb calls.  

Works when running in a local docker container with a wandb workspace.    Need to test it with a large run.  


<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
-

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
